### PR TITLE
Only affect imdbRating if there is one

### DIFF
--- a/app/controllers/api/v1/movie_controller.rb
+++ b/app/controllers/api/v1/movie_controller.rb
@@ -7,6 +7,7 @@ class Api::V1::MovieController < ApplicationController
     render_movie
   end
 
+  private
 
   def render_movie
     response.status = 200

--- a/app/presenters/movie.rb
+++ b/app/presenters/movie.rb
@@ -25,7 +25,7 @@ class Movie
       :imdbRating,
       :Type
     )
-    data[:imdbRating] += "/10"
+    data[:imdbRating] += "/10" if data[:imdbRating]
     return data
   end
 


### PR DESCRIPTION
#### Description

* I believe there's an issue with the `details` method of `Movie` where if there's no `:imdbRating` in the OMDb Request, then it can't add the `/10` rating. Now only affecting this attribute if it exists.

----
#### Issues # and Action

----
#### TO DO / Noteworthy
* Deploy again

----
#### Features
- [ ] New Feature
- [ ] Expand Feature
- [x] Optimize/Improve Feature


----
#### Testing
- [ ] No Testing
- [ ] Some Testing
- [ ] Sufficient Testing

- [ ] **I have left notes near functions that have not been tested**
- [ ] **I have included intentionally skipped / failing / empty tests as a reminder to add/improve these later**

- [ ] Tests have been changed
- [ ] Existing tests are now failing / skipped

----
#### Deployment

< deployment issue card # >

- [x] This is a complete feature, ready for deployment
- [ ] This is a partial feature, NOT ready for deployment


----
#### API Changes
(please detail in description)
- [ ] New API
- [ ] Existing API, New Endpoint

- [ ] **I have updated the README.md**

----
#### Tech Changes
(please detail in description)
- [ ] New Functional Library
- [ ] New Testing Library
- [ ] New Debugging Tool

- [ ] **I have updated the README.md**
